### PR TITLE
Add possibility to define hosts with path for Ingress

### DIFF
--- a/nuxeo/templates/ingress.yaml
+++ b/nuxeo/templates/ingress.yaml
@@ -13,7 +13,21 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+{{- if .Values.nuxeo.ingress.hosts }}
+  rules:
+    {{- range .Values.nuxeo.ingress.hosts }}
+      {{- $url := splitList "/" . }}
+    - host: {{ first $url }}
+      http:
+        paths:
+          - path: /{{ rest $url | join "/" }}
+            backend:
+              serviceName: {{ template "nuxeo.fullname" $ }}
+              servicePort: {{ $.Values.nuxeo.service.externalPort}}
+    {{- end }}
+{{- else }}
   backend:
     serviceName: {{ template "nuxeo.fullname" . }}
     servicePort: {{ .Values.nuxeo.service.externalPort}}
+{{- end -}}
 {{- end -}}

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -50,6 +50,10 @@ nuxeo:
     deploy: false
   ingress:
     enabled: false
+## Uncomment and update when custom hosts are needed for Ingress
+#    hosts:
+#      - my-host/nuxeo
+#      - my-host.domain.com/nuxeo
     annotations:
       kubernetes.io/ingress.class: nginx
   persistence:


### PR DESCRIPTION
This change enables to define hosts with path for Ingress. 
Hosts with path can be then defined in _values.yaml_ like this:
```
nuxeo:
  ingress:
    enabled: true
    hosts:
      - my-host/nuxeo
      - my-hots.domain.com/nuxeo
```